### PR TITLE
Fix httplib2

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -43,7 +43,7 @@ RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 RUN alternatives --set python3 /usr/bin/python3.11
 RUN python3 -m ensurepip
-RUN pip3 install httplib2 six requests filecheck
+RUN pip3 install httplib2==0.22.0 six requests filecheck
 
 # clone depot_tools and add it to your path
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git


### PR DESCRIPTION
`httplib2.socks` is removed in the latest version of httplib2 (0.30.0):
https://github.com/httplib2/httplib2/pull/247

Using version 0.22.0 until patches are applied to gclient upstream.