### PR TITLE
Add cc_wrapper.sh

### DIFF
--- a/bin/cc_wrapper.sh
+++ b/bin/cc_wrapper.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+#  Copyright IBM Corp. and others 2025
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# This wrapper is only needed when `treat_warnings_as_errors = true` is set.
+# You can avoid using it if you disable that flag in your GN args file.
+
+# We apply `-Wno-unknown-warning-option` globally because we use an older
+# version of Clang than Chromium upstream. As a result, some newer compiler flags
+# may not be recognized by our compiler and would otherwise cause errors.
+# This option suppresses those warnings. Alternatively, you can use
+# `-Wno-error=unknown-warning-option` to keep them visible as warnings instead of
+# treating them as errors.
+extra_flags="-Wno-unknown-warning-option"
+is_third_party=false
+
+# Check if we are building third party libs
+for arg in "$@"; do
+  case "$arg" in
+    *third_party/*)
+      is_third_party=true
+      break
+      ;;
+  esac
+done
+
+arch=$(uname -m)
+
+if [ "$is_third_party" = true ]; then
+  if [ "$arch" = "ppc64le" ]; then
+    # Needed to silence simdutf errors on conversion between vector types.
+    extra_flags="$extra_flags -Wno-deprecate-lax-vec-conv-all"
+    # Needed to silence fuzztest errors on conversion between vector types.
+    extra_flags="$extra_flags -Wno-deprecated-altivec-src-compat"
+  elif [ "$arch" = "s390x" ]; then
+    :
+  else
+    echo "We only build on ppc64le and s390x, exiting!"
+    exit 1
+  fi
+fi
+
+# Forward everything through ccache with the extra flags
+exec ccache "$@" $extra_flags

--- a/bin/entryPoint.sh
+++ b/bin/entryPoint.sh
@@ -109,6 +109,7 @@ mkdir -p out/$MACHINE_ARCH
 cp /home/$MACHINE_ARCH/$MODE.gn out/$MACHINE_ARCH/args.gn
 gn gen /home/v8/out/$MACHINE_ARCH
 ninja -C /home/v8/out/$MACHINE_ARCH -j $NPROC
+cp /home/cc_wrapper.sh /bin && chmod +x /bin/cc_wrapper.sh
 
 # run tests
 python3 tools/run-tests.py -j $NPROC --time --progress=dots --timeout=240 --no-presubmit \

--- a/bin/ppc64/debug.gn
+++ b/bin/ppc64/debug.gn
@@ -1,7 +1,6 @@
 is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
-treat_warnings_as_errors = false
 is_component_build = true
 target_cpu = "ppc64"
 v8_target_cpu = "ppc64"
@@ -11,4 +10,4 @@ v8_enable_object_print = true
 v8_enable_verify_heap = true
 is_debug = true
 symbol_level = 0
-cc_wrapper = "ccache"
+cc_wrapper = "cc_wrapper.sh"

--- a/bin/ppc64/ptrcompr_debug.gn
+++ b/bin/ppc64/ptrcompr_debug.gn
@@ -1,7 +1,6 @@
 is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
-treat_warnings_as_errors = false
 is_component_build = true
 target_cpu = "ppc64"
 v8_target_cpu = "ppc64"
@@ -12,4 +11,4 @@ v8_enable_verify_heap = true
 is_debug = true
 symbol_level = 0
 v8_enable_pointer_compression = true
-cc_wrapper = "ccache"
+cc_wrapper = "cc_wrapper.sh"

--- a/bin/ppc64/ptrcompr_release.gn
+++ b/bin/ppc64/ptrcompr_release.gn
@@ -1,7 +1,6 @@
 is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
-treat_warnings_as_errors = false
 is_component_build = false
 target_cpu = "ppc64"
 v8_target_cpu = "ppc64"
@@ -11,4 +10,4 @@ v8_enable_object_print = true
 v8_enable_verify_heap = true
 is_debug = false
 v8_enable_pointer_compression = true
-cc_wrapper = "ccache"
+cc_wrapper = "cc_wrapper.sh"

--- a/bin/ppc64/release.gn
+++ b/bin/ppc64/release.gn
@@ -1,7 +1,6 @@
 is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
-treat_warnings_as_errors = false
 is_component_build = false
 target_cpu = "ppc64"
 v8_target_cpu = "ppc64"
@@ -10,4 +9,4 @@ v8_enable_disassembler = true
 v8_enable_object_print = true
 v8_enable_verify_heap = true
 is_debug = false
-cc_wrapper = "ccache"
+cc_wrapper = "cc_wrapper.sh"

--- a/bin/s390x/debug.gn
+++ b/bin/s390x/debug.gn
@@ -1,7 +1,6 @@
 is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
-treat_warnings_as_errors = false
 is_component_build = true
 target_cpu = "s390x"
 v8_target_cpu = "s390x"
@@ -11,4 +10,4 @@ v8_enable_object_print = true
 v8_enable_verify_heap = true
 is_debug = true
 symbol_level = 0
-cc_wrapper = "ccache"
+cc_wrapper = "cc_wrapper.sh"

--- a/bin/s390x/ptrcompr_debug.gn
+++ b/bin/s390x/ptrcompr_debug.gn
@@ -1,7 +1,6 @@
 is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
-treat_warnings_as_errors = false
 is_component_build = true
 target_cpu = "s390x"
 v8_target_cpu = "s390x"
@@ -12,4 +11,4 @@ v8_enable_verify_heap = true
 is_debug = true
 symbol_level = 0
 v8_enable_pointer_compression = true
-cc_wrapper = "ccache"
+cc_wrapper = "cc_wrapper.sh"

--- a/bin/s390x/ptrcompr_release.gn
+++ b/bin/s390x/ptrcompr_release.gn
@@ -1,7 +1,6 @@
 is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
-treat_warnings_as_errors = false
 is_component_build = false
 target_cpu = "s390x"
 v8_target_cpu = "s390x"
@@ -11,4 +10,4 @@ v8_enable_object_print = true
 v8_enable_verify_heap = true
 is_debug = false
 v8_enable_pointer_compression = true
-cc_wrapper = "ccache"
+cc_wrapper = "cc_wrapper.sh"

--- a/bin/s390x/release.gn
+++ b/bin/s390x/release.gn
@@ -1,7 +1,6 @@
 is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
-treat_warnings_as_errors = false
 is_component_build = false
 target_cpu = "s390x"
 v8_target_cpu = "s390x"
@@ -10,4 +9,4 @@ v8_enable_disassembler = true
 v8_enable_object_print = true
 v8_enable_verify_heap = true
 is_debug = false
-cc_wrapper = "ccache"
+cc_wrapper = "cc_wrapper.sh"


### PR DESCRIPTION
This wrapper allows us to set `treat_warnings_as_errors = true` and selectively use Clang flags when needed.