### PR TITLE
enable clang by default

### DIFF
--- a/bin/ppc64/debug.gn
+++ b/bin/ppc64/debug.gn
@@ -1,4 +1,3 @@
-is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
 is_component_build = true

--- a/bin/ppc64/ptrcompr_debug.gn
+++ b/bin/ppc64/ptrcompr_debug.gn
@@ -1,4 +1,3 @@
-is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
 is_component_build = true

--- a/bin/ppc64/ptrcompr_release.gn
+++ b/bin/ppc64/ptrcompr_release.gn
@@ -1,4 +1,3 @@
-is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
 is_component_build = false

--- a/bin/ppc64/release.gn
+++ b/bin/ppc64/release.gn
@@ -1,4 +1,3 @@
-is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
 is_component_build = false

--- a/bin/s390x/debug.gn
+++ b/bin/s390x/debug.gn
@@ -1,4 +1,3 @@
-is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
 is_component_build = true

--- a/bin/s390x/ptrcompr_debug.gn
+++ b/bin/s390x/ptrcompr_debug.gn
@@ -1,4 +1,3 @@
-is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
 is_component_build = true

--- a/bin/s390x/ptrcompr_release.gn
+++ b/bin/s390x/ptrcompr_release.gn
@@ -1,4 +1,3 @@
-is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
 is_component_build = false

--- a/bin/s390x/release.gn
+++ b/bin/s390x/release.gn
@@ -1,4 +1,3 @@
-is_clang = true
 clang_base_path = "/usr"
 clang_use_chrome_plugins = false
 is_component_build = false


### PR DESCRIPTION
Clang is now enabled by default upstream for P/Z Linux:
https://chromium-review.googlesource.com/c/chromium/src/+/7081753