### PR TITLE
silence clang warning

### DIFF
--- a/bin/cc_wrapper.sh
+++ b/bin/cc_wrapper.sh
@@ -25,9 +25,12 @@
 # `-Wno-error=unknown-warning-option` to keep them visible as warnings instead of
 # treating them as errors.
 extra_flags="-Wno-unknown-warning-option"
-is_third_party=false
 
-# Check if we are building third party libs
+# Libc++ only supports Clang 20 and later.
+extra_flags="$extra_flags -Wno-#warnings"
+
+# Check if we are building third party libs.
+is_third_party=false
 for arg in "$@"; do
   case "$arg" in
     *third_party/*)
@@ -53,5 +56,5 @@ if [ "$is_third_party" = true ]; then
   fi
 fi
 
-# Forward everything through ccache with the extra flags
+# Forward everything through ccache with the extra flags.
 exec ccache "$@" $extra_flags

--- a/bin/ppc64/debug.gn
+++ b/bin/ppc64/debug.gn
@@ -10,4 +10,3 @@ v8_enable_verify_heap = true
 is_debug = true
 symbol_level = 0
 cc_wrapper = "cc_wrapper.sh"
-treat_warnings_as_errors = false

--- a/bin/ppc64/ptrcompr_debug.gn
+++ b/bin/ppc64/ptrcompr_debug.gn
@@ -11,4 +11,3 @@ is_debug = true
 symbol_level = 0
 v8_enable_pointer_compression = true
 cc_wrapper = "cc_wrapper.sh"
-treat_warnings_as_errors = false

--- a/bin/ppc64/ptrcompr_release.gn
+++ b/bin/ppc64/ptrcompr_release.gn
@@ -10,4 +10,3 @@ v8_enable_verify_heap = true
 is_debug = false
 v8_enable_pointer_compression = true
 cc_wrapper = "cc_wrapper.sh"
-treat_warnings_as_errors = false

--- a/bin/ppc64/release.gn
+++ b/bin/ppc64/release.gn
@@ -9,4 +9,3 @@ v8_enable_object_print = true
 v8_enable_verify_heap = true
 is_debug = false
 cc_wrapper = "cc_wrapper.sh"
-treat_warnings_as_errors = false

--- a/bin/s390x/debug.gn
+++ b/bin/s390x/debug.gn
@@ -10,4 +10,3 @@ v8_enable_verify_heap = true
 is_debug = true
 symbol_level = 0
 cc_wrapper = "cc_wrapper.sh"
-treat_warnings_as_errors = false

--- a/bin/s390x/ptrcompr_debug.gn
+++ b/bin/s390x/ptrcompr_debug.gn
@@ -11,4 +11,3 @@ is_debug = true
 symbol_level = 0
 v8_enable_pointer_compression = true
 cc_wrapper = "cc_wrapper.sh"
-treat_warnings_as_errors = false

--- a/bin/s390x/ptrcompr_release.gn
+++ b/bin/s390x/ptrcompr_release.gn
@@ -10,4 +10,3 @@ v8_enable_verify_heap = true
 is_debug = false
 v8_enable_pointer_compression = true
 cc_wrapper = "cc_wrapper.sh"
-treat_warnings_as_errors = false

--- a/bin/s390x/release.gn
+++ b/bin/s390x/release.gn
@@ -9,4 +9,3 @@ v8_enable_object_print = true
 v8_enable_verify_heap = true
 is_debug = false
 cc_wrapper = "cc_wrapper.sh"
-treat_warnings_as_errors = false


### PR DESCRIPTION
Need to silence the following Clang warning until it is upgraded:
```
error: "Libc++ only supports Clang 20 and later" [-Werror,-W#warnings]
```