### PR TITLE
Fix libc++ warning

### DIFF
--- a/bin/cc_wrapper.sh
+++ b/bin/cc_wrapper.sh
@@ -19,7 +19,8 @@
 # You can avoid using it if you disable that flag in your GN args file.
 # TODO: Re-evaluate this list when upgrading Clang.
 
-extra_flags=""
+# Libc++ only supports Clang 21 and later.
+extra_flags="-Wno-#warnings"
 
 # Check if we are building third party libs.
 is_third_party=false


### PR DESCRIPTION
Needed due to this change:
https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx/+/426c6af80269cecffb3dc9ceed1b8698c2d57d54