### PR TITLE
Upgrade to clang 21 and rust 1.92

### DIFF
--- a/bin/cc_wrapper.sh
+++ b/bin/cc_wrapper.sh
@@ -19,8 +19,7 @@
 # You can avoid using it if you disable that flag in your GN args file.
 # TODO: Re-evaluate this list when upgrading Clang.
 
-# Libc++ only supports Clang 21 and later.
-extra_flags="-Wno-#warnings"
+extra_flags=""
 
 # Check if we are building third party libs.
 is_third_party=false

--- a/bin/install_toolchain.sh
+++ b/bin/install_toolchain.sh
@@ -16,8 +16,8 @@
 #
 
 RHEL_VERSION="8.10"
-CLANG_VERSION="20.1.8"
-RUST_VERSION="1.88.0"
+CLANG_VERSION="21.1.8"
+RUST_VERSION="1.92.0"
 
 # Pin subscription-manager release to match container OS version
 subscription-manager release --set="$RHEL_VERSION"

--- a/bin/v8.sh
+++ b/bin/v8.sh
@@ -64,7 +64,6 @@ fi
 # Also check excluded platform specific flags under BUILD.gn.
 find build/ \( -name "*.gn" -o -name "*.gni" \) | xargs sed -i \
   -e '/-Wno-unsafe-buffer-usage-in-static-sized-array/d' \
-  -e '/-Wno-uninitialized-const-pointer/d' \
   -e '/-Wno-unused-but-set-global/d' \
   -e '/-fno-lifetime-dse/d' \
   -e '/-fsanitize-ignore-for-ubsan-feature/d' \


### PR DESCRIPTION
Changes are needed after this commit: https://github.com/llvm/llvm-project/commit/2e2d90b.
A patch was uploaded here but may not be accepted since llvm upstream does not support clang < 21 anymore:
https://github.com/llvm/llvm-project/pull/212249