### PR TITLE
Build gn explicitly

### DIFF
--- a/bin/gn.sh
+++ b/bin/gn.sh
@@ -16,5 +16,5 @@
 #
 
 git clone https://gn.googlesource.com/gn
-cd gn && python3 build/gen.py && ninja -C out
+cd gn && python3 build/gen.py && ninja -C out gn
 out/gn_unittests

--- a/bin/install_toolchain.sh
+++ b/bin/install_toolchain.sh
@@ -33,6 +33,6 @@ cd ..
 
 # Build GN
 git clone https://gn.googlesource.com/gn && cd gn
-python3 build/gen.py && ninja -C out
+python3 build/gen.py && ninja -C out gn
 mv out/gn /usr/bin
 cd ..


### PR DESCRIPTION
Needed after https://gn-review.googlesource.com/c/gn/+/25080, as we are getting these errors:
```
 ./../tools/run_formatter.sh --diff && "/usr/bin/python3" "../tools/touch.py" check_formatter
Errors:
  failed to resolve fuchsia/third_party/clang/<arc>@integration (line 1): no such package: fuchsia/third_party/clang/<arc>
```